### PR TITLE
Migrate DB to Postgres/Supabase and switch file storage to Vercel Blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # 内容分享平台
+
+## 数据库迁移说明（MySQL -> Supabase）
+
+当前服务已切换为 `PostgreSQL` 驱动，以便连接 Supabase Postgres，实体结构保持不变（继续使用 TypeORM Entity）。  
+
+### 环境变量
+
+优先使用 Supabase 提供的连接串（按以下优先级读取）：
+
+```env
+POSTGRES_URL=postgres://<user>:<password>@<pooler-host>:6543/postgres?sslmode=require
+# 兼容:
+POSTGRES_PRISMA_URL=postgres://<user>:<password>@<pooler-host>:6543/postgres?sslmode=require&pgbouncer=true
+# 旧变量:
+SUPABASE_DB_URL=postgres://<user>:<password>@<pooler-host>:6543/postgres?sslmode=require
+DB_SSL=true
+```
+
+## 文件存储迁移说明（腾讯云 COS -> Vercel Blob）
+
+上传接口已从腾讯云 COS 切换为 Vercel Blob：
+
+- 单图上传：`POST /upload/image`
+- 多图上传：`POST /upload/images`
+
+环境变量：
+
+```env
+# 变量名固定为 BLOB_READ_WRITE_TOKEN
+BLOB_READ_WRITE_TOKEN=<your-vercel-blob-token>
+```
+
+也支持分项配置（未配置 `SUPABASE_DB_URL` 时使用）：
+
+```env
+POSTGRES_HOST=<your-supabase-host>
+POSTGRES_PORT=6543
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=<password>
+POSTGRES_DATABASE=postgres
+
+# 兼容旧变量:
+DB_HOST=<your-supabase-host>
+DB_PORT=6543
+DB_USERNAME=postgres
+DB_PASSWORD=<password>
+DB_DATABASE=postgres
+DB_SSL=true
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,11 @@ services:
       - '3000:3000'
     restart: always
     environment:
-      - DATABASE_HOST=${HOST_IP}
-      - DATABASE_PORT=3306
-      - DATABASE_USER=root
-      - DATABASE_PASSWORD=admin123
-      - DATABASE_NAME=content_sharing_platform
+      - POSTGRES_URL=${POSTGRES_URL}
+      - POSTGRES_HOST=${POSTGRES_HOST}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DATABASE=${POSTGRES_DATABASE}
+      - BLOB_READ_WRITE_TOKEN=${BLOB_READ_WRITE_TOKEN}
+      - DB_SSL=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "content-sharing-platform",
   "version": "0.0.1",
+  "packageManager": "pnpm@8.15.9",
   "engines": {
     "node": "20.x",
     "pnpm": "8.x"
@@ -33,13 +34,12 @@
     "@nestjs/swagger": "^8.1.0",
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.4.15",
+    "@vercel/blob": "^0.27.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "commitizen": "^4.3.1",
     "cookie-parser": "^1.4.7",
-    "cos-nodejs-sdk-v5": "^2.14.6",
-    "mysql2": "^3.11.5",
-    "qcloud-cos-sts": "^3.1.1",
+    "pg": "^8.13.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,7 @@
 import { Module } from '@nestjs/common';
 import { UserModule } from './user/user.module';
 import { SocketModule } from './socket/socket.module';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { configOptions, typeormOptions } from './config';
+import { configOptions, TypeOrmConfigModule } from './config';
 import { PostModule } from './post/post.module';
 import { MediaModule } from './media/media.module';
 import { ConfigModule } from '@nestjs/config';
@@ -17,7 +16,7 @@ import { UploadModule } from './upload/upload.module';
 import { CartModule } from './cart/cart.module';
 
 @Module({
-  imports: [ConfigModule.forRoot(configOptions), TypeOrmModule.forRoot(typeormOptions), UserModule, SocketModule, PostModule, MediaModule, AuthModule, MessageModule, GroupModule, UserGroupModule, ProductModule, ConversationModule, CommentModule, UploadModule, CartModule],
+  imports: [ConfigModule.forRoot(configOptions), TypeOrmConfigModule, UserModule, SocketModule, PostModule, MediaModule, AuthModule, MessageModule, GroupModule, UserGroupModule, ProductModule, ConversationModule, CommentModule, UploadModule, CartModule],
   controllers: [],
   providers: [],
 })

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,28 +3,67 @@ import { TypeOrmModule, TypeOrmModuleOptions } from "@nestjs/typeorm";
 import { join } from "path";
 
 export const typeormOptions: TypeOrmModuleOptions = {
-    type: 'mysql',
+    type: 'postgres',
     host: 'localhost',
-    port: 3306,
-    username: 'root',
-    password: 'admin123',
-    database: 'content_sharing_platform',
+    port: 6543,
+    username: 'postgres',
+    password: 'postgres',
+    database: 'postgres',
     entities: [join(__dirname, '../**', '*.entity{.ts,.js}')],
     synchronize: true,
+    ssl: {
+        rejectUnauthorized: false,
+    },
 }
 
 export const TypeOrmConfigModule = TypeOrmModule.forRootAsync({
     imports: [ConfigModule],
-    useFactory: (configService: ConfigService) => ({
-        type: 'mysql',
-        host: configService.get('DB_HOST'),
-        port: configService.get<number>('DB_PORT'),
-        username: configService.get('DB_USERNAME'),
-        password: configService.get('DB_PASSWORD'),
-        database: configService.get('DB_DATABASE'),
-        entities: [join(__dirname, '../**', '*.entity{.ts,.js}')],
-        synchronize: true,
-    }),
+    useFactory: (configService: ConfigService): TypeOrmModuleOptions => {
+        const databaseUrl =
+            configService.get<string>('POSTGRES_URL') ||
+            configService.get<string>('POSTGRES_PRISMA_URL') ||
+            configService.get<string>('SUPABASE_DB_URL');
+        const shouldUseSsl = configService.get('DB_SSL', 'true') === 'true';
+
+        if (databaseUrl) {
+            return {
+                type: 'postgres',
+                url: databaseUrl,
+                entities: [join(__dirname, '../**', '*.entity{.ts,.js}')],
+                synchronize: true,
+                ssl: shouldUseSsl
+                    ? {
+                        rejectUnauthorized: false,
+                    }
+                    : false,
+            };
+        }
+
+        const host = configService.get<string>('POSTGRES_HOST') ?? configService.get<string>('DB_HOST');
+        const port =
+            configService.get<number>('POSTGRES_PORT') ??
+            configService.get<number>('DB_PORT') ??
+            6543;
+        const username = configService.get<string>('POSTGRES_USER') ?? configService.get<string>('DB_USERNAME');
+        const password = configService.get<string>('POSTGRES_PASSWORD') ?? configService.get<string>('DB_PASSWORD');
+        const database = configService.get<string>('POSTGRES_DATABASE') ?? configService.get<string>('DB_DATABASE') ?? 'postgres';
+
+        return {
+            type: 'postgres',
+            host,
+            port,
+            username,
+            password,
+            database,
+            entities: [join(__dirname, '../**', '*.entity{.ts,.js}')],
+            synchronize: true,
+            ssl: shouldUseSsl
+                ? {
+                    rejectUnauthorized: false,
+                }
+                : false,
+        };
+    },
     inject: [ConfigService],
 })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ConfigService } from '@nestjs/config';
 import { initSwaggerDocument } from './swagger';
-import * as cookieParser from 'cookie-parser';
+import cookieParser = require('cookie-parser');
 import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {

--- a/src/upload/upload.controller.ts
+++ b/src/upload/upload.controller.ts
@@ -2,47 +2,31 @@ import { Controller, Post, UploadedFile, UploadedFiles, UseInterceptors } from '
 import { FileInterceptor, FilesInterceptor } from '@nestjs/platform-express';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { MediaService } from 'src/media/media.service';
 import { successResponse } from 'src/utils';
-import * as COS from 'cos-nodejs-sdk-v5';
 import { ConfigService } from '@nestjs/config';
+import { put } from '@vercel/blob';
 
 @Controller('upload')
 export class UploadController {
-    bucket = 'season-1313247063';
-    region = 'ap-chengdu';
-    cos = new COS({});
     constructor(
-        private readonly mediaService: MediaService,
         private readonly configService: ConfigService
-    ) {
-        // 从环境变量获取 SecretId 和 SecretKey，避免硬编码在代码中
-        this.cos = new COS({
-            SecretId: this.configService.get('COS_SECRET_ID'),
-            SecretKey: this.configService.get('COS_SECRET_KEY'),
-        });
-    }
-    uploadCos = async (file: Express.Multer.File) => {
-        const bucket = this.bucket;
-        const region = this.region;
+    ) { }
+
+    uploadToVercelBlob = async (file: Express.Multer.File) => {
         const md5Hash = crypto.createHash('md5').update(file.buffer).digest('hex');
         const key = `uploads/${md5Hash}${path.extname(file.originalname)}`;
+        const token = this.configService.get<string>('BLOB_READ_WRITE_TOKEN');
+        if (!token) {
+            throw new Error('Missing env: BLOB_READ_WRITE_TOKEN');
+        }
 
-        return new Promise((resolve, reject) => {
-            this.cos.putObject({
-                Bucket: bucket,
-                Region: region,
-                Key: key,
-                Body: file.buffer,
-            }, async (err) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    const url = `https://${bucket}.cos.${region}.myqcloud.com/${key}`;
-                    resolve(url)
-                }
-            })
+        const result = await put(key, file.buffer, {
+            access: 'public',
+            token,
+            addRandomSuffix: false,
         })
+
+        return result.url;
     }
 
     @Post('image')
@@ -50,7 +34,7 @@ export class UploadController {
         limits: { fileSize: 1024 * 1024 * 5 }, // 限制文件大小为 5MB
     }))
     async uploadImage(@UploadedFile() file: Express.Multer.File) {
-        const url = await this.uploadCos(file);
+        const url = await this.uploadToVercelBlob(file);
         return successResponse(url);
     }
 
@@ -58,7 +42,7 @@ export class UploadController {
     @Post('images')
     @UseInterceptors(FilesInterceptor('images'))
     async uploadImages(@UploadedFiles() files: Array<Express.Multer.File>) {
-        const res = await Promise.all(files.map((file) => this.uploadCos(file)));
+        const res = await Promise.all(files.map((file) => this.uploadToVercelBlob(file)));
         return successResponse(res);
     }
 

--- a/src/upload/upload.module.ts
+++ b/src/upload/upload.module.ts
@@ -1,13 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UploadController } from './upload.controller';
 import { MediaModule } from 'src/media/media.module';
-import { MediaService } from 'src/media/media.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Media } from 'src/entities';
 
 @Module({
   imports: [MediaModule, TypeOrmModule.forFeature([Media])],
-  providers: [MediaService],
   controllers: [UploadController]
 })
 export class UploadModule { }


### PR DESCRIPTION
### Motivation

- Replace existing MySQL/COS setup with Postgres (Supabase-compatible) and Vercel Blob storage to support Supabase hosting and Vercel Blob for uploaded files.
- Make connection and credential handling more flexible by supporting URL-based and individual env var configuration and enabling SSL for managed Postgres.

### Description

- Switched TypeORM default driver from MySQL to Postgres and introduced `TypeOrmConfigModule` with support for `POSTGRES_URL`, `POSTGRES_PRISMA_URL`, `SUPABASE_DB_URL` or explicit `POSTGRES_*`/`DB_*` env vars and conditional SSL (`DB_SSL`).
- Reworked upload flow to use `@vercel/blob` (`put`) instead of Tencent COS and added environment token `BLOB_READ_WRITE_TOKEN`; removed COS dependencies and related service wiring.
- Updated `docker-compose.yml` to expose Postgres-related environment variables and `BLOB_READ_WRITE_TOKEN` instead of MySQL variables.
- Updated `package.json` to add `@vercel/blob`, replace `mysql2`/COS libs with `pg`, and set `packageManager` to `pnpm@8.15.9`, and adjusted `AppModule` and `main.ts` integration for the new config module and cookie-parser import style.

### Testing

- Ran unit tests with `pnpm test` (Jest) and the test suite completed successfully.
- Verified application can start locally with updated config by running the Nest app (`pnpm start:dev`) and basic upload endpoints return URLs when `BLOB_READ_WRITE_TOKEN` is provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb864cce3083208c3123c03d1e43e6)